### PR TITLE
Fix 2 spaces between words when copying

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -139,7 +139,7 @@ function Editor({ monosyllabic }: { monosyllabic: MonosyllabicData }) {
           onClick={() => {
             const toCopy = convertedWords.converted
               .map((info) => (info.kind === "mono" ? info.mono : info.orig))
-              .join(" ");
+              .join("");
             navigator.clipboard.writeText(toCopy);
             setShowCopied(true);
           }}


### PR DESCRIPTION
When pressing "Copy Monosyllabic", result has 2 spaces between words instead of 1

Copy result on from https://paralogical.dev/glish/ :
```
Type   a   stes   or   preft   in   here   in   glish   to   see   its   shlayr. 

 This   is   some   shuh   plimdz   text   to   smud.
 ```
 
Copy result with this change:
 ```
 Type a stes or preft in here in glish to see its shlayr.

This is some shuh plimdz text to smud.
```